### PR TITLE
feat: Get ID from headers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -453,6 +453,7 @@
 * [UserinfoToJSON](README.md#userinfotojson)
 * [canConsumeForm](README.md#canconsumeform)
 * [exists](README.md#exists)
+* [getIDFromHeaders](README.md#getidfromheaders)
 * [isBlob](README.md#const-isblob)
 * [mapValues](README.md#mapvalues)
 * [querystring](README.md#querystring)
@@ -3254,6 +3255,39 @@ Name | Type |
 `key` | string |
 
 **Returns:** *boolean*
+
+___
+
+###  getIDFromHeaders
+
+▸ **getIDFromHeaders**(`resp`: Response): *string*
+
+Get ID from `location` header
+
+This function is used to get the ID resources
+created in Folio (where you are redirected
+afterwards).
+
+**`example`** 
+```typescript
+import { getIDFromHeaders } from 'fiken';
+
+...
+
+const res = await fiken.createBankAccountRaw({
+ ...
+});
+
+const id = getIDFromHeaders(res.raw);
+```
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`resp` | Response |
+
+**Returns:** *string*
 
 ___
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+};

--- a/src/__tests__/id-from-header.test.ts
+++ b/src/__tests__/id-from-header.test.ts
@@ -1,0 +1,27 @@
+import { getIDFromHeaders } from '../libs/id-from-header';
+import { Response } from 'node-fetch';
+describe('id-from-header.ts', () => {
+  const url =
+    'https://api.fiken.no/api/v2/companies/fiken-demo-historisk-fasong-as1/bankAccounts/1933231237';
+
+  it('should resolve location header', () => {
+    const response = new Response(
+      null,
+      {
+        headers: {
+          location: url,
+        },
+      },
+    );
+    
+    expect(getIDFromHeaders(response)).toBe('1933231237');
+  });
+
+  it('should fail if no location is in headers', () => {
+      const response = new Response(null, {
+          headers: {},
+      });
+      expect(() => getIDFromHeaders(response)).toThrowError();
+  })
+
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './generated';
+export * from './libs/id-from-header';

--- a/src/libs/id-from-header.ts
+++ b/src/libs/id-from-header.ts
@@ -1,0 +1,29 @@
+/**
+ * Get ID from `location` header
+ * 
+ * This function is used to get the ID resources
+ * created in Folio (where you are redirected
+ * afterwards).
+ * 
+ * @example
+ * ```typescript
+ * import { getIDFromHeaders } from 'fiken';
+ * 
+ * ...
+ * 
+ * const res = await fiken.createBankAccountRaw({
+ *  ...
+ * });
+ * 
+ * const id = getIDFromHeaders(res.raw);
+ * ```
+ */
+export function getIDFromHeaders(resp: Response): string {
+    const loc = resp.headers.get('location');
+    if (!loc) {
+        throw new Error('location header was not found');
+    }
+
+    const url = loc.split('/');
+    return url.pop();    
+}


### PR DESCRIPTION
As there are a few methods in the Fiken API where the body is empty, and users need to get the ID of a created resource.

Some of the methods in Fiken API you can create a resource, but it doesn't respond with any data. The same methods often/always sends a location header (e.g. `location: https://api.fiken.no/api/v2/companies/fiken-demo-historisk-fasong-as1/bankAccounts/1933231237`). This pull requests adds a function to retrieve the ID of that `location` header.

Example:

```typescript
const res = await fiken.createBankAccountRaw({
  companySlug,
  bankAccountRequest,
});

const id = getIDFromHeaders(res.raw);
// example: id = 1933231237
```