### PR TITLE
fix: Uploading issues

### DIFF
--- a/src/generated/apis/CreditNotesApi.ts
+++ b/src/generated/apis/CreditNotesApi.ts
@@ -37,6 +37,7 @@ import {
     SendCreditNoteRequestFromJSON,
     SendCreditNoteRequestToJSON,
 } from '../models';
+import { createReadStream } from 'fs';
 
 export interface AddAttachmentToCreditNoteDraftRequest {
     companySlug: string;
@@ -146,32 +147,24 @@ export class CreditNotesApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const {
+          filename,
+          file,
+        } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
+          formParams.append('file', file, filename);
+        } 
 
         if (requestParameters.comment !== undefined) {
             formParams.append('comment', requestParameters.comment as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -179,7 +172,7 @@ export class CreditNotesApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);

--- a/src/generated/apis/InboxApi.ts
+++ b/src/generated/apis/InboxApi.ts
@@ -19,6 +19,7 @@ import {
     InboxResultFromJSON,
     InboxResultToJSON,
 } from '../models';
+import { createReadStream } from 'fs';
 
 export interface CreateInboxDocumentRequest {
     companySlug: string;
@@ -68,36 +69,25 @@ export class InboxApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const { filename, file } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
+          formParams.append('file', file, filename);
+        } 
 
         if (requestParameters.name !== undefined) {
             formParams.append('name', requestParameters.name as any);
         }
 
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
-
         if (requestParameters.description !== undefined) {
             formParams.append('description', requestParameters.description as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -105,7 +95,7 @@ export class InboxApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);

--- a/src/generated/apis/InvoicesApi.ts
+++ b/src/generated/apis/InvoicesApi.ts
@@ -37,6 +37,7 @@ import {
     UpdateInvoiceRequestFromJSON,
     UpdateInvoiceRequestToJSON,
 } from '../models';
+import { createReadStream } from 'fs';
 
 export interface AddAttachmentToInvoiceRequest {
     companySlug: string;
@@ -164,36 +165,25 @@ export class InvoicesApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const { filename, file } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
-        }
-
+          formParams.append('file', file, filename);
+        } 
+        
         const response = await this.request({
             path: `/companies/{companySlug}/invoices/{invoiceId}/attachments`.replace(`{${"companySlug"}}`, encodeURIComponent(String(requestParameters.companySlug))).replace(`{${"invoiceId"}}`, encodeURIComponent(String(requestParameters.invoiceId))),
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -231,32 +221,21 @@ export class InvoicesApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const { filename, file } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
+          formParams.append('file', file, filename);
+        } 
 
         if (requestParameters.comment !== undefined) {
             formParams.append('comment', requestParameters.comment as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -264,7 +243,7 @@ export class InvoicesApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);

--- a/src/generated/apis/OffersApi.ts
+++ b/src/generated/apis/OffersApi.ts
@@ -28,6 +28,7 @@ import {
     OfferFromJSON,
     OfferToJSON,
 } from '../models';
+import { createReadStream } from 'fs';
 
 export interface AddAttachmentToOfferDraftRequest {
     companySlug: string;
@@ -115,32 +116,21 @@ export class OffersApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const { filename, file } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
+          formParams.append('file', file, filename);
         }
 
         if (requestParameters.comment !== undefined) {
             formParams.append('comment', requestParameters.comment as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -148,7 +138,7 @@ export class OffersApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);

--- a/src/generated/apis/PurchasesApi.ts
+++ b/src/generated/apis/PurchasesApi.ts
@@ -34,6 +34,7 @@ import {
     PurchaseResultFromJSON,
     PurchaseResultToJSON,
 } from '../models';
+import { createReadStream } from 'fs';
 
 export interface AddAttachmentToPurchaseRequest {
     companySlug: string;
@@ -157,36 +158,30 @@ export class PurchasesApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const {
+          filename,
+          attachToPayment,
+          attachToSale,
+          file,
+        } = requestParameters;
+
+        if (attachToPayment !== undefined) {
+            formParams.append('attachToPayment', attachToPayment as any);
+        }
+
+        if (attachToSale !== undefined) {
+            formParams.append('attachToSale', attachToSale as any);
+        }
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
-
-        if (requestParameters.attachToPayment !== undefined) {
-            formParams.append('attachToPayment', requestParameters.attachToPayment as any);
-        }
-
-        if (requestParameters.attachToSale !== undefined) {
-            formParams.append('attachToSale', requestParameters.attachToSale as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
+          formParams.append('file', file, filename);
         }
 
         const response = await this.request({
@@ -194,7 +189,7 @@ export class PurchasesApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -221,7 +216,7 @@ export class PurchasesApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        const headerParameters: runtime.HTTPHeaders = {};
+        let headerParameters: runtime.HTTPHeaders = {};
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
@@ -232,28 +227,20 @@ export class PurchasesApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const {
+          filename,
+          file,
+        } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
+          formParams.append('file', file, filename);
         }
 
         const response = await this.request({
@@ -261,7 +248,7 @@ export class PurchasesApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);

--- a/src/generated/apis/SalesApi.ts
+++ b/src/generated/apis/SalesApi.ts
@@ -34,6 +34,7 @@ import {
     SaleResultFromJSON,
     SaleResultToJSON,
 } from '../models';
+import { createReadStream } from 'fs';
 
 export interface AddAttachmentToSaleRequest {
     companySlug: string;
@@ -162,25 +163,18 @@ export class SalesApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const { filename, file } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
+          formParams.append('file', file, filename);
+        } 
 
         if (requestParameters.attachToPayment !== undefined) {
             formParams.append('attachToPayment', requestParameters.attachToPayment as any);
@@ -190,16 +184,12 @@ export class SalesApi extends runtime.BaseAPI {
             formParams.append('attachToSale', requestParameters.attachToSale as any);
         }
 
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
-        }
-
         const response = await this.request({
             path: `/companies/{companySlug}/sales/{saleId}/attachments`.replace(`{${"companySlug"}}`, encodeURIComponent(String(requestParameters.companySlug))).replace(`{${"saleId"}}`, encodeURIComponent(String(requestParameters.saleId))),
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -237,36 +227,25 @@ export class SalesApi extends runtime.BaseAPI {
             }
         }
 
-        const consumes: runtime.Consume[] = [
-            { contentType: 'multipart/form-data' },
-        ];
-        // @ts-ignore: canConsumeForm may be unused
-        const canConsumeForm = runtime.canConsumeForm(consumes);
+        const formParams = new FormData();
 
-        let formParams: { append(param: string, value: any): any };
-        let useForm = false;
-        // use FormData to transmit files using content-type "multipart/form-data"
-        useForm = canConsumeForm;
-        if (useForm) {
-            formParams = new FormData();
+        const { filename, file } = requestParameters;
+
+        formParams.append('filename', filename as any);
+
+        if (typeof file === 'string') {
+          const stream = createReadStream(file);
+          formParams.append('file', stream, filename);
         } else {
-            formParams = new URLSearchParams();
-        }
-
-        if (requestParameters.filename !== undefined) {
-            formParams.append('filename', requestParameters.filename as any);
-        }
-
-        if (requestParameters.file !== undefined) {
-            formParams.append('file', requestParameters.file as any);
-        }
+          formParams.append('file', file, filename);
+        } 
 
         const response = await this.request({
             path: `/companies/{companySlug}/sales/drafts/{draftId}/attachments`.replace(`{${"companySlug"}}`, encodeURIComponent(String(requestParameters.companySlug))).replace(`{${"draftId"}}`, encodeURIComponent(String(requestParameters.draftId))),
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formParams,
+            formBody: formParams,
         });
 
         return new runtime.VoidApiResponse(response);


### PR DESCRIPTION
FormData object is serialized with `JSON.stringify` which caused the Fiken API to return a `500` on a few methods. This pull request fixes that and refactors everywhere `FormData` is used to be clearer (less generator boilerplate).

Instead of using `body` for `FormData`, there is now a specific property (`formBody`).

The issue is likely caused by:

https://github.com/bjerkio/fiken-js/blob/497c2cf86f4281b5a7bf45d18fcd82a8618c4206/src/generated/runtime.ts#L53-L55

Specificially, `typeof FormData !== "undefined" && context.body instanceof FormData` which is **not** `true` for methods that actually use `FormData`.